### PR TITLE
[METRICS-3477] Add template for mounting kafka.properties

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -143,6 +143,7 @@ type DruidSpec struct {
 
 	// Optional: Custom Dimension Map Path for statsd emitter
 	DimensionsMapPath string `json:"metricDimensions.json,omitempty"`
+	KafkaPropertiesPath string `json:"kafka.properties,omitempty"`
 }
 
 type DruidNodeSpec struct {

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -546,6 +546,8 @@ spec:
                 type: object
               metricDimensions.json:
                 type: string
+              kafka.properties:
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -807,9 +807,9 @@ func makeCommonConfigMap(m *v1alpha1.Druid, ls map[string]string) (*v1.ConfigMap
 		data["metricDimensions.json"] = m.Spec.DimensionsMapPath
 	}
 
-  if m.Spec.KafkaPropertiesPath != "" {
-    data["kafka.properties"] = m.Spec.KafkaPropertiesPath
-  }
+	if m.Spec.KafkaPropertiesPath != "" {
+		data["kafka.properties"] = m.Spec.KafkaPropertiesPath
+	}
 
 	cfg, err := makeConfigMap(
 		fmt.Sprintf("%s-druid-common-config", m.ObjectMeta.Name),

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -807,6 +807,10 @@ func makeCommonConfigMap(m *v1alpha1.Druid, ls map[string]string) (*v1.ConfigMap
 		data["metricDimensions.json"] = m.Spec.DimensionsMapPath
 	}
 
+  if m.Spec.KafkaPropertiesPath != "" {
+    data["kafka.properties"] = m.Spec.KafkaPropertiesPath
+  }
+
 	cfg, err := makeConfigMap(
 		fmt.Sprintf("%s-druid-common-config", m.ObjectMeta.Name),
 		m.Namespace,


### PR DESCRIPTION
Mount kafka.properties as configmap for now. 