### PR TITLE
update obs-data team as codeownder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# See go/codeowners - automatically generated for confluentinc/druid-operator:
-*	@confluentinc/observability
+*	@confluentinc/obs-data


### PR DESCRIPTION
update obs-data team as codeownders of confluent druid-operator repo.