### PR TITLE
[METRICS-4487] add obs-oncall as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*	@confluentinc/obs-data
-*       @confluentinc/obs-oncall
+*	@confluentinc/obs-data @confluentinc/obs-oncall

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *	@confluentinc/obs-data
+*       @confluentinc/obs-oncall


### PR DESCRIPTION
When oncall is not codeowner of certain repo, even though secondary may has approved primary oncall’s PR, it still can be merged to fix incidents, especially during night/weekends. (eg. metrics team cannot approve PR for druid repo). I looked into github and didn’t find anything like creating a dynamic oncall group as codeowner. I don’t think github support that. So we need to update the team member of the github oncall group every week manually.

This PR added the static `obs-oncall` github group as one of CODEOWNERS.  It means it requires x group, or `obs-oncall` group to approve the PR to get merged.