### PR TITLE
Node's nodeSelector should override spec's nodeSelector

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1158,7 +1158,7 @@ func makePodTemplate(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 // makePodSpec shall create podSpec common to both deployment and statefulset.
 func makePodSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUniqueStr, configMapSHA string) v1.PodSpec {
 	spec := v1.PodSpec{
-		NodeSelector:              firstNonNilValue(m.Spec.NodeSelector, nodeSpec.NodeSelector).(map[string]string),
+		NodeSelector:              firstNonNilValue(nodeSpec.NodeSelector, m.Spec.NodeSelector).(map[string]string),
 		Tolerations:      getTolerations(nodeSpec, m),
 		Affinity:         getAffinity(nodeSpec, m),
 		ImagePullSecrets: firstNonNilValue(nodeSpec.ImagePullSecrets, m.Spec.ImagePullSecrets).([]v1.LocalObjectReference),


### PR DESCRIPTION
### Description
We have two nodeSelectors at spec level and node level. We want the node's nodeSelector to override the common spec's nodeSelector. So, changing the order.
