### PR TITLE
OBSDATA-492: Add confluentinc specific changes to master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/obs-data
+*	@confluentinc/obs-data @confluentinc/obs-oncall

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# See go/codeowners - automatically generated for confluentinc/druid-operator:
+*	@confluentinc/observability

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# See go/codeowners - automatically generated for confluentinc/druid-operator:
-*	@confluentinc/observability
+*	@confluentinc/obs-data

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -7,12 +7,20 @@ spec:
   visibility: private
   repository:
     url: git@github.com:confluentinc/druid-operator.git
+    run_on:
+    - branches
+    - tags
+    - pull_requests
     pipeline_file: .semaphore/semaphore.yml
     integration_type: github_app
     status:
       pipeline_files:
       - path: .semaphore/semaphore.yml
         level: pipeline
+    whitelist:
+      branches:
+      - master
+      - cc-druid-operator
   custom_permissions: true
   debug_permissions:
   - empty

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,29 @@
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: druid-operator
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/druid-operator.git
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,27 @@
+version: v1.0
+name: druid-operator
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu1804
+
+blocks:
+  - name: Build, Test
+    task:
+      prologue:
+        commands:
+          - sem-version go 1.15
+          - checkout
+      jobs:
+        - name: Build
+          env_vars:
+            - name: KUBEBUILDER_VERSION
+              value: 2.3.1
+            - name: OS_ARCH
+              value: amd64
+          commands:
+            - make init-ci
+            # Build and Test
+            - go mod download
+            - make manager
+            - make test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,7 @@ version: v1.0
 name: druid-operator
 agent:
   machine:
-    type: e1-standard-4
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 
 blocks:
   - name: Build, Test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,18 +9,10 @@ blocks:
     task:
       prologue:
         commands:
-          - sem-version go 1.15
+          - sem-version go 1.17
           - checkout
       jobs:
-        - name: Build
-          env_vars:
-            - name: KUBEBUILDER_VERSION
-              value: 2.3.1
-            - name: OS_ARCH
-              value: amd64
+        - name: Build and Test
           commands:
-            - make init-ci
-            # Build and Test
-            - go mod download
             - make manager
             - make test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,10 +9,13 @@ blocks:
     task:
       prologue:
         commands:
-          - sem-version go 1.17
+          - sem-version go 1.19
           - checkout
       jobs:
-        - name: Build and Test
+        - name: Build, Test
           commands:
-            - make manager
+            - make build
             - make test
+            - make lint
+            - make template
+            - make docker-build

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,13 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
+init-ci:
+	# Install kubebuilder
+	curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz"
+	tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz
+	mv kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH} kubebuilder
+	export PATH=$PATH:kubebuilder/bin
+
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 .PHONY: all
-all: build
+all: build test lint template docker-build
 
 ##@ General
 
@@ -88,13 +88,6 @@ docker-push: ## Push docker image with the manager.
 ifndef ignore-not-found
   ignore-not-found = false
 endif
-
-init-ci:
-	# Install kubebuilder
-	curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz"
-	tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz
-	mv kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH} kubebuilder
-	export PATH=$PATH:kubebuilder/bin
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -91,8 +91,15 @@ type DruidSpec struct {
 	// +optional
 	DeleteOrphanPvc bool `json:"deleteOrphanPvc"`
 
-	// Required: path to druid start script to be run on container start
+	// Required: Command to be run on container start
 	StartScript string `json:"startScript"`
+
+	// Optional: bash/sh entry arg. Set startScript to `sh` or `bash` to customize entryArg
+	// For example, the container can run `sh -c "${EntryArg} && ${DruidScript} {nodeType}"`
+	EntryArg string `json:"entryArg,omitempty"`
+
+	// Optional: Customized druid shell script path. If not set, the default would be "bin/run-druid.sh"
+	DruidScript string `json:"druidScript,omitempty"`
 
 	// Required here or at nodeSpec level
 	Image string `json:"image,omitempty"`

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -8847,6 +8847,10 @@ spec:
                 description: 'Required: path to druid start script to be run on container
                   start'
                 type: string
+              entryArg:
+                type: string
+              druidScript:
+                type: string
               startUpProbe:
                 description: 'Optional: StartupProbe for nodeSpec'
                 properties:

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 
 	autoscalev2beta2 "k8s.io/api/autoscaling/v2beta2"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -1138,6 +1139,21 @@ func getVolume(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUniq
 	return volumesHolder
 }
 
+func getCommand(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []string {
+	if m.Spec.StartScript != "" && m.Spec.EntryArg != "" {
+		return []string{m.Spec.StartScript}
+	}
+	return []string{firstNonEmptyStr(m.Spec.StartScript, "bin/run-druid.sh"), nodeSpec.NodeType}
+}
+
+func getEntryArg(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []string {
+	if m.Spec.EntryArg != "" {
+		bashCommands := strings.Join([]string{m.Spec.EntryArg, "&&", firstNonEmptyStr(m.Spec.DruidScript, "bin/run-druid.sh"), nodeSpec.NodeType}, " ")
+		return []string{"-c", bashCommands}
+	}
+	return nil
+}
+
 func getEnv(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, configMapSHA string) []v1.EnvVar {
 	envHolder := firstNonNilValue(nodeSpec.Env, m.Spec.Env).([]v1.EnvVar)
 	// enables to do the trick to force redeployment in case of configmap changes.
@@ -1308,7 +1324,8 @@ func makePodSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUn
 		v1.Container{
 			Image:           firstNonEmptyStr(nodeSpec.Image, m.Spec.Image),
 			Name:            fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Command:         []string{firstNonEmptyStr(m.Spec.StartScript, "bin/run-druid.sh"), nodeSpec.NodeType},
+			Command:         getCommand(nodeSpec, m),
+			Args:            getEntryArg(nodeSpec, m),
 			ImagePullPolicy: v1.PullPolicy(firstNonEmptyStr(string(nodeSpec.ImagePullPolicy), string(m.Spec.ImagePullPolicy))),
 			Ports:           nodeSpec.Ports,
 			Resources:       nodeSpec.Resources,

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1362,7 +1362,7 @@ func makePodSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUn
 	}
 
 	spec := v1.PodSpec{
-		NodeSelector:                  firstNonNilValue(m.Spec.NodeSelector, nodeSpec.NodeSelector).(map[string]string),
+		NodeSelector:                  firstNonNilValue(nodeSpec.NodeSelector, m.Spec.NodeSelector).(map[string]string),
 		TopologySpreadConstraints:     getTopologySpreadConstraints(nodeSpec),
 		Tolerations:                   getTolerations(nodeSpec, m),
 		Affinity:                      getAffinity(nodeSpec, m),

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,19 +19,7 @@ spec:
           image: druidio/druid-operator:latest
           command:
           - /manager
-          imagePullPolicy: Always
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8081
-            initialDelaySeconds: 15
-            periodSeconds: 20
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8081
-            initialDelaySeconds: 5
-            periodSeconds: 10
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/examples/tiny-cluster-zk.yaml
+++ b/examples/tiny-cluster-zk.yaml
@@ -53,11 +53,8 @@ spec:
             - containerPort: 3888
               name: zk-elec-port
           resources:
-            limits:
-              cpu: 1
-              memory: 512Mi
             requests:
-              cpu: 1
+              cpu: 100m
               memory: 512Mi
           volumeMounts:
             - mountPath: /data

--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -6,7 +6,7 @@ kind: "Druid"
 metadata:
   name: tiny-cluster
 spec:
-  image: apache/druid:0.22.1
+  image: confluent-docker.jfrog.io/confluentinc/cc-druid:v1.202.0
   # Optionally specify image for all nodes. Can be specify on nodes also
   # imagePullSecrets:
   # - name: tutu
@@ -31,7 +31,7 @@ spec:
   commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
   jvm.options: |-
     -server
-    -XX:MaxDirectMemorySize=10240g
+    -XX:MaxDirectMemorySize=1g
     -Duser.timezone=UTC
     -Dfile.encoding=UTF-8
     -Dlog4j.debug
@@ -52,6 +52,8 @@ spec:
         </Loggers>
     </Configuration>
   common.runtime.properties: |
+    druid.startup.logging.logProperties=true
+    druid.sql.enable=true
 
     # Zookeeper
     druid.zk.service.host=tiny-cluster-zk-0.tiny-cluster-zk
@@ -59,19 +61,37 @@ spec:
     druid.zk.service.compress=false
 
     # Metadata Store
-    druid.metadata.storage.type=derby
-    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
-    druid.metadata.storage.connector.host=localhost
-    druid.metadata.storage.connector.port=1527
-    druid.metadata.storage.connector.createTables=true
+    # druid.metadata.storage.type=derby
+    # druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
+    # druid.metadata.storage.connector.host=localhost
+    # druid.metadata.storage.connector.port=1527
+    # druid.metadata.storage.connector.createTables=true
+    druid.metadata.storage.type=postgresql
+    druid.metadata.storage.connector.connectURI=jdbc:postgresql://druid-metadata-postgresql.tiny-cluster.svc.cluster.local:5432/druiddb
+    druid.metadata.storage.connector.user=druidpguser
+    druid.metadata.storage.connector.password=druidpgpassword
 
     # Deep Storage
-    druid.storage.type=local
-    druid.storage.storageDirectory=/druid/deepstorage
+    # druid.storage.type=local
+    # druid.storage.storageDirectory=/druid/deepstorage
+    druid.storage.type=s3
+    druid.storage.bucket=druidio
+    druid.storage.baseKey=local/segments
+
+    # Indexing service logs
+    druid.indexer.logs.type=s3
+    druid.indexer.logs.s3Bucket=druidio
+    druid.indexer.logs.s3Prefix=local/indexing-logs
+    druid.s3.protocol=http
+    druid.s3.endpoint.url=minio.minio.svc.cluster.local:9000
+    druid.s3.enablePathStyleAccess=true
+    druid.s3.accessKey=AKIAIOSFODNN7EXAMPLE
+    druid.s3.secretKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
     #
     # Extensions
     #
-    druid.extensions.loadList=["druid-kafka-indexing-service"]
+    druid.extensions.loadList=["postgresql-metadata-storage", "druid-s3-extensions", "druid-kafka-indexing-service", "druid-datasketches", "druid-basic-security", "druid-opencensus-extensions", "statsd-emitter", "confluent-extensions"]
 
     #
     # Service discovery
@@ -259,6 +279,8 @@ spec:
         path: /tmp/druid/deepstorage
         type: DirectoryOrCreate
   env:
+    - name: AWS_REGION
+      value: us-east-1
     - name: POD_NAME
       valueFrom:
         fieldRef:
@@ -292,6 +314,10 @@ spec:
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
+      resources:
+        requests:
+          memory: "600Mi"
+          cpu: "200m"
 
     coordinators:
       # Optionally specify for running coordinator as Deployment
@@ -315,6 +341,10 @@ spec:
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
+      resources:
+        requests:
+          memory: "600Mi"
+          cpu: "200m"
 
     historicals:
       nodeType: "historical"
@@ -324,37 +354,78 @@ spec:
       runtime.properties: |
         druid.service=druid/historical
         druid.server.http.numThreads=5
-        druid.processing.buffer.sizeBytes=536870912
         druid.processing.numMergeBuffers=1
         druid.processing.numThreads=1
-
+        druid.processing.buffer.sizeBytes=268435456
         # Segment storage
         druid.segmentCache.locations=[{\"path\":\"/druid/data/segments\",\"maxSize\":10737418240}]
         druid.server.maxSize=10737418240
       extra.jvm.options: |-
-        -Xmx512M
-        -Xms512M
+        -Xmx1G
+        -Xms1G
+        -XX:MaxDirectMemorySize=1g
+      resources:
+        requests:
+          memory: "2G"
+          cpu: "1000m"
           
     routers:
       nodeType: "router"
+      # Optionally specify for broker nodes
+      # imagePullSecrets:
+      # - name: tutu
       druid.port: 8088
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/router"
       replicas: 1
       runtime.properties: |
         druid.service=druid/router
-
-        # HTTP proxy
-        druid.router.http.numConnections=10
-        druid.router.http.readTimeout=PT5M
-        druid.router.http.numMaxThreads=10
+        druid.router.managementProxy.enabled=true
+        # HTTP server threads
+        druid.router.http.numConnections=5
         druid.server.http.numThreads=10
-
-        # Service discovery
-        druid.router.defaultBrokerServiceName=druid/broker
-        druid.router.coordinatorServiceName=druid/coordinator
-
-        # Management proxy to coordinator / overlord: required for unified web console.
-        druid.router.managementProxy.enabled=true       
+        # Processing threads and buffers
+        druid.processing.buffer.sizeBytes=1
+        druid.processing.numMergeBuffers=1
+        druid.processing.numThreads=1
       extra.jvm.options: |-
-        -Xmx512M
-        -Xms512M
+        -Xmx512m
+        -Xms512m
+      resources:
+        requests:
+          memory: "600Mi"
+          cpu: "200m"
+      ingress:
+        rules:
+          - host: druid.tiny.test
+            http:
+              paths:
+                - path: /
+                  backend:
+                    serviceName: druid-tiny-cluster-routers
+                    servicePort: 8088
+
+    middlemanagers:
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/data/middleManager"
+      nodeType: "middleManager"
+      druid.port: 8091
+      replicas: 1
+      runtime.properties: |-
+        druid.service=druid/middleManager
+        druid.worker.capacity=1
+        druid.indexer.runner.javaOpts=-server -XX:MaxDirectMemorySize=1g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/druid/data/tmp -Dlog4j.debug -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=50 -XX:GCLogFileSize=10m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Xloggc:/druid/data/logs/peon.gc.%t.%p.log -XX:HeapDumpPath=/druid/data/logs/peon.%t.%p.hprof -Xms1G -Xmx1G
+        druid.indexer.task.baseTaskDir=/druid/data/baseTaskDir
+        druid.server.http.numThreads=10
+        druid.indexer.fork.property.druid.processing.buffer.sizeBytes=268435456
+        druid.indexer.fork.property.druid.processing.numMergeBuffers=1
+        druid.indexer.fork.property.druid.processing.numThreads=1
+      extra.jvm.options: |-
+        -Xmx1G
+        -Xms1G
+      readinessProbe:
+        httpGet:
+          path: /status/health
+          port: 8091
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "400m"

--- a/minikube-setup.md
+++ b/minikube-setup.md
@@ -1,0 +1,193 @@
+# Druid on minikube
+This doc has step-by-step instructions on how to deploy a local druid cluster on [minikube](https://github.com/kubernetes/minikube).
+I chose minikube instead of a local docker install because it works for both Linux and MacOS. 
+
+
+## 1. Setup minikube
+
+a. Install minikube ([installation instructions](https://minikube.sigs.k8s.io/docs/start/))
+
+b. Start a minikube cluster. I chose to allocate 4 CPUs, 12 GB of RAM and 60G of disk. 
+```shell script
+minikube start  --cpus 4 --memory 12192 -v 9 --disk-size 60G
+```
+
+c. Enable the ingress controller and ingress-dns addon.
+```shell script
+minikube addons enable ingress
+minikube addons enable ingress-dns
+```
+
+Please make sure that you follow the steps [here](https://github.com/kubernetes/minikube/tree/master/deploy/addons/ingress-dns) to add minikube as the dns resolver for `*.test` domain. 
+
+Hint: On MacOS you will need to kill the mDNSResponder for the dns changes to start working and also reload Mac OS mDNS resolver.
+```shell script
+sudo killall -HUP mDNSResponder
+sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
+sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
+```
+
+## 2. Install minio (storage server with S3 compatible api) for deep storage
+
+a. Install the chart.
+```shell script
+helm repo add minio https://helm.min.io/
+
+kubectl create ns minio
+
+helm upgrade \
+    --install minio minio/minio \
+    --namespace minio \
+    --set resources.requests.memory=2Gi \
+    --set persistence.size=500Gi \
+    --set accessKey=AKIAIOSFODNN7EXAMPLE \
+    --set secretKey="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+    --set ingress.enabled=true \
+    --set ingress.hosts={minio.tiny.test} \
+    --debug
+```
+
+b. Verify that the pods are healthy and check logs.
+```shell script
+kubectl get pods -n minio
+kubectl -n minio logs -l app=minio
+```
+c. Access the minio web console at http://minio.tiny.test (use the apikey and access key from the Helm command in step a )
+If this doesnot work make sure the ingress-dns and ingress controller are setup correctly (step c. in the section on minikube)
+
+d. Create a bucket named `druidio` from the minio web console.
+
+## 3. Install Postgres for metadata storage
+
+a. Create a namespace. We will install the druid cluster in this namespace. If you change the namespace here, take care to update the namespace all of the other components below.
+```shell script
+kubectl create ns tiny-cluster
+```
+b. Install the postgres chart.
+```shell script
+helm repo add bitnami https://charts.bitnami.com/bitnami
+
+helm upgrade \
+  --install druid-metadata bitnami/postgresql \
+  --namespace tiny-cluster \
+  --set postgresqlUsername=druidpguser \
+  --set postgresqlPassword=druidpgpassword \
+  --set postgresqlDatabase=druiddb \
+  --debug
+```
+
+c. Make sure the postgres pods and up and running.
+```shell script
+kubectl get pods -n tiny-cluster
+kubectl logs -n tiny-cluster druid-metadata-postgresql-0
+```
+
+## 4. Install the Druid operator
+a. Clone the repo and switch to `kick-tires` branch.
+```shell script
+git clone https://github.com/confluentinc/druid-operator.git
+git checkout cc-druid-operator
+```
+
+b. Create the required k8s resources.
+```shell script
+kubectl create --namespace tiny-cluster -f deploy/service_account.yaml
+# Setup RBAC
+kubectl create --namespace tiny-cluster -f deploy/role.yaml
+kubectl create --namespace tiny-cluster -f deploy/role_binding.yaml
+# Setup the CRD
+kubectl create --namespace tiny-cluster -f deploy/crds/druid.apache.org_druids.yaml
+```
+c. Deploy the druid-operator
+```shell script
+eval $(minikube -p minikube docker-env)
+
+make docker-build
+kubectl apply --namespace tiny-cluster -f deploy/operator.yaml
+```
+d. Check the deployed druid-operator. Make sure the pods are up and running.
+```shell script
+kubectl describe --namespace tiny-cluster deployment druid-operator
+kubectl get pods -n tiny-cluster
+kubectl -n tiny-cluster logs -l app=druid-operator
+```
+
+## 4.Deploy druid cluster
+ 
+a. Pull the image manually until I figure out how to add image secrets
+```shell script
+eval $(minikube -p minikube docker-env)
+docker pull confluent-docker.jfrog.io/confluentinc/cc-druid:v1.202.0
+```
+b. Create the zookeeper cluster.
+```shell script
+kubectl apply --namespace tiny-cluster -f examples/tiny-cluster-zk.yaml
+```
+c. Create the Druid CRD.
+```shell script
+kubectl apply --namespace tiny-cluster -f examples/tiny-cluster.yaml
+```
+d. Verify that all pods are up and running
+```shell script
+kubectl get pods --namespace tiny-cluster
+```
+e. Access the Druid console at http://druid.tiny.test .
+
+## 5. (Optional) Install turnilo (fork of Druid Pivot project, for slicing and dicing data)
+
+a. Deploy and create ingress.
+```shell script
+kubectl run turnilo \
+    --namespace tiny-cluster \
+    --image=node:12 \
+    --port=9090 \
+    --command -- bash -c "npm install -g turnilo && turnilo --druid http://druid-tiny-cluster-routers:8088"
+
+kubectl expose deployment turnilo --namespace tiny-cluster --port=9090
+
+cat <<EOF | kubectl apply --namespace tiny-cluster -f -
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: turnilo-ingress
+spec:
+  rules:
+  - host: turnilo.tiny.test
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: turnilo
+          servicePort: 9090
+EOF
+
+```
+b. Access the UI at http://turnlio.tiny.test
+
+
+## 6. (Optional) Install Grafana (for creating dashboards)
+```shell script
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm upgrade \
+  --install grafana bitnami/grafana \
+  --namespace tiny-cluster \
+  --set plugins=abhisant-druid-datasource \
+  --set admin.password=admin \
+  --set ingress.enabled=true \
+  --set "ingress.hosts[0].name"=grafana.tiny.test \
+  --debug
+```
+
+# Development
+
+## How to run the operator locally
+```shell script
+mkdir -p tmp && cd tmp
+export RELEASE_VERSION=v0.11.0;curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
+ln -s operator-sdk-v0.11.0-x86_64-apple-darwin operator-sdk
+chmod +x operator-sdk-v0.11.0-x86_64-apple-darwin
+cd ..
+make build
+tmp/operator-sdk up local
+```

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,13 @@
+name: druid-operator
+lang: unknown
+lang_version: unknown
+git:
+  enable: true
+github:
+  enable: true
+  repo_name: confluentinc/druid-operator
+semaphore:
+  enable: true
+  pipeline_enable: false
+  triggers: []
+  branches: []

--- a/service.yml
+++ b/service.yml
@@ -9,5 +9,9 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
-  triggers: []
-  branches: []
+  triggers:
+  - branches
+  - pull_requests
+  branches:
+  - master
+  - cc-druid-operator


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
https://confluentinc.atlassian.net/browse/OBSDATA-492
Add confluentinc specific changes to master
Changelog:

* Adding minikube-setup instructions.

Update tiny-cluster.yaml to make it work in minikube.

Fixing operator startup bug.

Miscellaneous fixes to make local minikube setup work.

Fixing MM readiness probe and steps for minikube ingress-dns issue for local minikube setup.

* semaphore (#5)

* Add command args to container creation (#6)

* go/codeowners: Generate CODEOWNERS [ci skip] (#7)

* [METRICS-4348] update obs-data team as codeownderswq (#8)

* [METRICS-4487] add obs-oncall as codeowners (#10)

* DP-8085 - Migrate to Sempahore self-hosted agent (#9)

* DP-9370 - Migrate to Semaphore self-hosted agent (#15)

* chore: update repo semaphore project

* Update service.yml (#17)

Update semaphore job commands and go version

update build triggers

update semaphore whitelist

Update project.yml

* update CI 

* nodespec should take precedence (#13)



<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.(tested in stag)
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>


[METRICS-4348]: https://confluentinc.atlassian.net/browse/METRICS-4348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ