### PR TITLE
[OBSDATA-1485] List only pod specific to a nodespec while checking the crash status

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -567,14 +567,13 @@ func execCheckCrashStatus(sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, m
 		return
 	} else {
 		if nodeSpec.PodManagementPolicy == "OrderedReady" {
-			checkCrashStatus(sdk, m, event)
+			checkCrashStatus(sdk, nodeSpec, m, event)
 		}
 	}
 }
 
-func checkCrashStatus(sdk client.Client, drd *v1alpha1.Druid, emitEvents EventEmitter) error {
-
-	podList, err := readers.List(context.TODO(), sdk, drd, makeLabelsForDruid(drd.Name), emitEvents, func() objectList { return &v1.PodList{} }, func(listObj runtime.Object) []object {
+func checkCrashStatus(sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, drd *v1alpha1.Druid, emitEvents EventEmitter) error {
+	podList, err := readers.List(context.TODO(), sdk, drd, makeLabelsForNodeSpec(&nodeSpec, m, m.Name, makeNodeSpecificUniqueString(m, key)), emitEvents, func() objectList { return &v1.PodList{} }, func(listObj runtime.Object) []object {
 		items := listObj.(*v1.PodList).Items
 		result := make([]object, len(items))
 		for i := 0; i < len(items); i++ {

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -213,7 +213,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid, emitEvents EventEm
 				}
 
 				// Default is set to true
-				execCheckCrashStatus(sdk, &nodeSpec, m, emitEvents)
+				execCheckCrashStatus(sdk, &nodeSpec, m, nodeSpecUniqueStr, emitEvents)
 
 				// Ignore isObjFullyDeployed() for the first iteration ie cluster creation
 				// will force cluster creation in parallel, post first iteration rolling updates
@@ -228,7 +228,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid, emitEvents EventEm
 			}
 
 			// Default is set to true
-			execCheckCrashStatus(sdk, &nodeSpec, m, emitEvents)
+			execCheckCrashStatus(sdk, &nodeSpec, m, nodeSpecUniqueStr, emitEvents)
 		}
 
 		// Create Ingress Spec
@@ -562,18 +562,18 @@ func executeFinalizers(sdk client.Client, m *v1alpha1.Druid, emitEvents EventEmi
 
 }
 
-func execCheckCrashStatus(sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, event EventEmitter) {
+func execCheckCrashStatus(sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUniqueStr string, event EventEmitter) {
 	if m.Spec.ForceDeleteStsPodOnError == false {
 		return
 	} else {
 		if nodeSpec.PodManagementPolicy == "OrderedReady" {
-			checkCrashStatus(sdk, nodeSpec, m, event)
+			checkCrashStatus(sdk, nodeSpec, m, nodeSpecUniqueStr, event)
 		}
 	}
 }
 
-func checkCrashStatus(sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, drd *v1alpha1.Druid, emitEvents EventEmitter) error {
-	podList, err := readers.List(context.TODO(), sdk, drd, makeLabelsForNodeSpec(&nodeSpec, m, m.Name, makeNodeSpecificUniqueString(m, key)), emitEvents, func() objectList { return &v1.PodList{} }, func(listObj runtime.Object) []object {
+func checkCrashStatus(sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, drd *v1alpha1.Druid, nodeSpecUniqueStr string, emitEvents EventEmitter) error {
+	podList, err := readers.List(context.TODO(), sdk, drd, makeLabelsForNodeSpec(nodeSpec, drd, drd.Name, nodeSpecUniqueStr), emitEvents, func() objectList { return &v1.PodList{} }, func(listObj runtime.Object) []object {
 		items := listObj.(*v1.PodList).Items
 		result := make([]object, len(items))
 		for i := 0; i < len(items); i++ {


### PR DESCRIPTION


<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

### What
Fix [OBSDATA-1485](https://confluentinc.atlassian.net/browse/OBSDATA-1485)

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

[druid-operator/controllers/druid/handler.go at 80d52cc2e261a22aea7a861409cc9c878da0fcab · confluentinc/druid-operator](https://github.com/confluentinc/druid-operator/blob/80d52cc2e261a22aea7a861409cc9c878da0fcab/controllers/druid/handler.go#L560) 
in the function when we are iterating over nodespec and deploying each statefulset one by one, we are calling the `checkCrashStatus` to see if there are any pods which are not ready. But we are listing all the pods from the [druid deployment](https://github.com/confluentinc/druid-operator/blob/80d52cc2e261a22aea7a861409cc9c878da0fcab/controllers/druid/handler.go#L562) instead of the pods which are specific to the current nodespec

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>




[OBSDATA-1485]: https://confluentinc.atlassian.net/browse/OBSDATA-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ