### PR TITLE
Dev ECR Migration - Please Review by Dec 15 to Avoid Interruption.

### DIFF
--- a/config/samples/storage.confluent.io_v1_localstorage.yaml
+++ b/config/samples/storage.confluent.io_v1_localstorage.yaml
@@ -8,8 +8,8 @@ spec:
   replicas: 1
   instanceType: i3.large
   forceDeploy: false 
-  eksNVMEProvisionerImage: "755363985185.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-eks-nvme-ssd-provisioner:v0.19.0"
-  nodeGrabberImage: "755363985185.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-base-alpine:v2.7.0"
+  eksNVMEProvisionerImage: "519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-eks-nvme-ssd-provisioner:v0.19.0"
+  nodeGrabberImage: "519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-base-alpine:v2.7.0"
   localVolumeProvisionerImage: "quay.io/external_storage/local-volume-provisioner:v2.3.3"
   serviceAccountName: druid-operator 
   storageClassName: local-storage

--- a/controllers/storage.confluent.io/testdata/enp-daemonset.yaml
+++ b/controllers/storage.confluent.io/testdata/enp-daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         operator-version: storage.confluent.io-v1
     spec:
       containers:
-      - image: 755363985185.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-eks-nvme-ssd-provisioner:v0.19.0
+      - image: 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-eks-nvme-ssd-provisioner:v0.19.0
         imagePullPolicy: Always
         name: eks-nvme-provisioner
         resources: {}

--- a/controllers/storage.confluent.io/testdata/localstorage-smoke-test-cluster.yaml
+++ b/controllers/storage.confluent.io/testdata/localstorage-smoke-test-cluster.yaml
@@ -7,8 +7,8 @@ spec:
   replicas: 1
   instanceType: i3.large
   forceDeploy: false 
-  eksNVMEProvisionerImage: "755363985185.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-eks-nvme-ssd-provisioner:v0.19.0"
-  nodeGrabberImage: "755363985185.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-base-alpine:v2.7.0"
+  eksNVMEProvisionerImage: "519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-eks-nvme-ssd-provisioner:v0.19.0"
+  nodeGrabberImage: "519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-base-alpine:v2.7.0"
   localVolumeProvisionerImage: "quay.io/external_storage/local-volume-provisioner:v2.3.3"
   serviceAccountName: druid-operator 
   storageClassName: local-storage

--- a/controllers/storage.confluent.io/testdata/nodegrabber-deployment.yaml
+++ b/controllers/storage.confluent.io/testdata/nodegrabber-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - tail
         - -f
         - /dev/null
-        image: 755363985185.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-base-alpine:v2.7.0
+        image: 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cc-base-alpine:v2.7.0
         imagePullPolicy: Always
         name: node-grabber
         ports:


### PR DESCRIPTION
#### What's new?
* Updates all references of 755363985185 to 519856050701
#### Why?
Devprod is moving the dev ECR repos from the 755363985185 AWS account to the 519856050701 account.
https://confluent.slack.com/archives/C038ZJ00P/p1701959664115029
https://confluent.slack.com/archives/C038ZJ00P/p1699569201298449
