### PR TITLE
OBSTEL-1601: Observability GH Team Cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/obs-data @confluentinc/obs-oncall
+*	@confluentinc/obs-data


### PR DESCRIPTION
OBSTEL-1601: Observability GH Team Cleanup

This PR cleans up references to the [observability ](https://github.com/orgs/confluentinc/teams/observability) and [obs-oncall](https://github.com/orgs/confluentinc/teams/obs-oncall) GitHub teams for [OBSTEL-1601](https://confluentinc.atlassian.net/browse/OBSTEL-1601). References to `@confluentinc/observability` will be replaced with a more specific team if one is not already present.


[OBSTEL-1601]: https://confluentinc.atlassian.net/browse/OBSTEL-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ